### PR TITLE
core: fix setting up of virtio features

### DIFF
--- a/include/kvm/virtio.h
+++ b/include/kvm/virtio.h
@@ -205,13 +205,13 @@ struct virtio_device {
 	void			*virtio;
 	struct virtio_ops	*ops;
 	u16			endian;
-	u32			features;
+	u64			features;
 	u32			status;
 };
 
 struct virtio_ops {
 	u8 *(*get_config)(struct kvm *kvm, void *dev);
-	u32 (*get_host_features)(struct kvm *kvm, void *dev);
+	u64 (*get_host_features)(struct kvm *kvm, void *dev);
 	int (*get_vq_count)(struct kvm *kvm, void *dev);
 	int (*init_vq)(struct kvm *kvm, void *dev, u32 vq);
 	void (*exit_vq)(struct kvm *kvm, void *dev, u32 vq);
@@ -243,7 +243,7 @@ bool virtio_read_config(struct kvm *kvm, struct virtio_device *vdev, void *dev,
 bool virtio_write_config(struct kvm *kvm, struct virtio_device *vdev, void *dev,
 			 unsigned long offset, void *data, size_t size);
 void virtio_set_guest_features(struct kvm *kvm, struct virtio_device *vdev,
-			       void *dev, u32 features);
+			       void *dev, u64 features);
 void virtio_notify_status(struct kvm *kvm, struct virtio_device *vdev,
 			  void *dev, u8 status);
 

--- a/virtio/blk.c
+++ b/virtio/blk.c
@@ -154,7 +154,7 @@ static u8 *get_config(struct kvm *kvm, void *dev)
 	return ((u8 *)(&bdev->blk_config));
 }
 
-static u32 get_host_features(struct kvm *kvm, void *dev)
+static u64 get_host_features(struct kvm *kvm, void *dev)
 {
 	struct blk_dev *bdev = dev;
 

--- a/virtio/core.c
+++ b/virtio/core.c
@@ -307,11 +307,11 @@ bool virtio_queue__should_signal(struct virt_queue *vq)
 }
 
 void virtio_set_guest_features(struct kvm *kvm, struct virtio_device *vdev,
-			       void *dev, u32 features)
+			       void *dev, u64 features)
 {
 	/* TODO: fail negotiation if features & ~host_features */
 
-	vdev->features = features;
+	vdev->features |= features;
 }
 
 void virtio_notify_status(struct kvm *kvm, struct virtio_device *vdev,


### PR DESCRIPTION
Features actually occupy more space then u32 provides, e.g. virtio-pci driver sets bits that extend beyond 31. Also, overwriting previously set features bits effectively breaks handshake for virtio-pci transport.