### PR TITLE
virtio-pci transport support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,17 @@ PREFIX=/usr/bin
 
 OBJS :=	device.o \
 	xs_dev.o \
+	pci.o \
 	demu.o
 
 
 OBJS	+= virtio/blk.o
 OBJS	+= virtio/core.o
 OBJS	+= virtio/mmio.o
+OBJS	+= virtio/pci.o
 OBJS	+= virtio/mmio-legacy.o
 OBJS	+= virtio/mmio-modern.o
+OBJS	+= virtio/pci-modern.o
 
 OBJS	+= disk/core.o
 OBJS	+= disk/blk.o
@@ -27,7 +30,7 @@ OBJS	+= util/util.o
 #CC  := $(CROSS_COMPILE)gcc
 #LD  := $(CROSS_COMPILE)ld
 
-CFLAGS  = -I$(shell pwd)/include
+CFLAGS  = -I. -I$(shell pwd)/include
 
 # _GNU_SOURCE for asprintf.
 CFLAGS += -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_GNU_SOURCE #-DMAP_IN_ADVANCE -DCONFIG_HAS_AIO

--- a/demu.c
+++ b/demu.c
@@ -548,6 +548,28 @@ demu_deregister_memory_space(uint64_t start)
                                                     1, start, end);
 }
 
+int demu_register_pcidev(uint8_t bus, uint8_t device, uint8_t function)
+{
+    DBG("%02x:%02x:%02x\n", bus, device, function);
+
+    return xendevicemodel_map_pcidev_to_ioreq_server(demu_state.xdh,
+                                                     demu_state.domid,
+                                                     demu_state.ioservid,
+                                                     0, bus, device, function);
+}
+
+
+void demu_deregister_pcidev(uint8_t bus, uint8_t device, uint8_t function)
+{
+    DBG("%02x:%02x:%02x\n", bus, device, function);
+
+    (void) xendevicemodel_unmap_pcidev_from_ioreq_server(demu_state.xdh,
+                                                         demu_state.domid,
+                                                         demu_state.ioservid,
+                                                         0, bus, device,
+                                                         function);
+}
+
 static void
 demu_handle_io(ioreq_t *ioreq)
 {

--- a/demu.h
+++ b/demu.h
@@ -49,6 +49,8 @@ int demu_register_memory_space(uint64_t start, uint64_t size,
     void *ptr);
 
 void demu_deregister_memory_space(uint64_t start);
+int demu_register_pcidev(uint8_t bus, uint8_t device, uint8_t function);
+void demu_deregister_pcidev(uint8_t bus, uint8_t device, uint8_t function);
 
 #ifdef MAP_IN_ADVANCE
 void *demu_get_host_addr(uint64_t offset);

--- a/include/kvm/ioport.h
+++ b/include/kvm/ioport.h
@@ -1,0 +1,45 @@
+#ifndef KVM__IOPORT_H
+#define KVM__IOPORT_H
+
+/* #include "kvm/kvm-cpu.h" */
+
+#include <asm/types.h>
+#include <linux/types.h>
+#include <linux/byteorder.h>
+
+/* some ports we reserve for own use */
+#define IOPORT_DBG			0xe0
+
+void ioport__map_irq(u8 *irq);
+
+static inline u8 ioport__read8(u8 *data)
+{
+	return *data;
+}
+/* On BE platforms, PCI I/O is byteswapped, i.e. LE, so swap back. */
+static inline u16 ioport__read16(u16 *data)
+{
+	return le16_to_cpu(*data);
+}
+
+static inline u32 ioport__read32(u32 *data)
+{
+	return le32_to_cpu(*data);
+}
+
+static inline void ioport__write8(u8 *data, u8 value)
+{
+	*data		 = value;
+}
+
+static inline void ioport__write16(u16 *data, u16 value)
+{
+	*data		 = cpu_to_le16(value);
+}
+
+static inline void ioport__write32(u32 *data, u32 value)
+{
+	*data		 = cpu_to_le32(value);
+}
+
+#endif /* KVM__IOPORT_H */

--- a/include/kvm/pci.h
+++ b/include/kvm/pci.h
@@ -1,0 +1,17 @@
+#ifndef KVM__PCI_H
+#define KVM__PCI_H
+
+#include <linux/types.h>
+#include <linux/virtio_pci.h>
+
+#define PCI_IO_SIZE           0x100
+
+struct virtio_caps {
+	struct virtio_pci_cap		common;
+	struct virtio_pci_notify_cap	notify;
+	struct virtio_pci_cap		isr;
+	struct virtio_pci_cap		device;
+	struct virtio_pci_cfg_cap	pci;
+};
+
+#endif /* KVM__PCI_H */

--- a/include/linux/virtio_pci.h
+++ b/include/linux/virtio_pci.h
@@ -1,0 +1,210 @@
+/*
+ * Virtio PCI driver
+ *
+ * This module allows virtio devices to be used over a virtual PCI device.
+ * This can be used with QEMU based VMMs like KVM or Xen.
+ *
+ * Copyright IBM Corp. 2007
+ *
+ * Authors:
+ *  Anthony Liguori  <aliguori@us.ibm.com>
+ *
+ * This header is BSD licensed so anyone can use the definitions to implement
+ * compatible drivers/servers.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of IBM nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL IBM OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_VIRTIO_PCI_H
+#define _LINUX_VIRTIO_PCI_H
+
+#include <linux/types.h>
+
+#ifndef VIRTIO_PCI_NO_LEGACY
+
+/* A 32-bit r/o bitmask of the features supported by the host */
+#define VIRTIO_PCI_HOST_FEATURES	0
+
+/* A 32-bit r/w bitmask of features activated by the guest */
+#define VIRTIO_PCI_GUEST_FEATURES	4
+
+/* A 32-bit r/w PFN for the currently selected queue */
+#define VIRTIO_PCI_QUEUE_PFN		8
+
+/* A 16-bit r/o queue size for the currently selected queue */
+#define VIRTIO_PCI_QUEUE_NUM		12
+
+/* A 16-bit r/w queue selector */
+#define VIRTIO_PCI_QUEUE_SEL		14
+
+/* A 16-bit r/w queue notifier */
+#define VIRTIO_PCI_QUEUE_NOTIFY		16
+
+/* An 8-bit device status register.  */
+#define VIRTIO_PCI_STATUS		18
+
+/* An 8-bit r/o interrupt status register.  Reading the value will return the
+ * current contents of the ISR and will also clear it.  This is effectively
+ * a read-and-acknowledge. */
+#define VIRTIO_PCI_ISR			19
+
+/* MSI-X registers: only enabled if MSI-X is enabled. */
+/* A 16-bit vector for configuration changes. */
+#define VIRTIO_MSI_CONFIG_VECTOR        20
+/* A 16-bit vector for selected queue notifications. */
+#define VIRTIO_MSI_QUEUE_VECTOR         22
+
+/* The remaining space is defined by each driver as the per-driver
+ * configuration space */
+#define VIRTIO_PCI_CONFIG_OFF(msix_enabled)	((msix_enabled) ? 24 : 20)
+/* Deprecated: please use VIRTIO_PCI_CONFIG_OFF instead */
+#define VIRTIO_PCI_CONFIG(dev)	VIRTIO_PCI_CONFIG_OFF((dev)->msix_enabled)
+
+/* Virtio ABI version, this must match exactly */
+#define VIRTIO_PCI_ABI_VERSION		0
+
+/* How many bits to shift physical queue address written to QUEUE_PFN.
+ * 12 is historical, and due to x86 page size. */
+#define VIRTIO_PCI_QUEUE_ADDR_SHIFT	12
+
+/* The alignment to use between consumer and producer parts of vring.
+ * x86 pagesize again. */
+#define VIRTIO_PCI_VRING_ALIGN		4096
+
+#endif /* VIRTIO_PCI_NO_LEGACY */
+
+/* The bit of the ISR which indicates a device configuration change. */
+#define VIRTIO_PCI_ISR_CONFIG		0x2
+/* Vector value used to disable MSI for queue */
+#define VIRTIO_MSI_NO_VECTOR            0xffff
+
+#ifndef VIRTIO_PCI_NO_MODERN
+
+/* IDs for different capabilities.  Must all exist. */
+
+/* Common configuration */
+#define VIRTIO_PCI_CAP_COMMON_CFG	1
+/* Notifications */
+#define VIRTIO_PCI_CAP_NOTIFY_CFG	2
+/* ISR access */
+#define VIRTIO_PCI_CAP_ISR_CFG		3
+/* Device specific configuration */
+#define VIRTIO_PCI_CAP_DEVICE_CFG	4
+/* PCI configuration access */
+#define VIRTIO_PCI_CAP_PCI_CFG		5
+/* Additional shared memory capability */
+#define VIRTIO_PCI_CAP_SHARED_MEMORY_CFG 8
+
+/* This is the PCI capability header: */
+struct virtio_pci_cap {
+	__u8 cap_vndr;		/* Generic PCI field: PCI_CAP_ID_VNDR */
+	__u8 cap_next;		/* Generic PCI field: next ptr. */
+	__u8 cap_len;		/* Generic PCI field: capability length */
+	__u8 cfg_type;		/* Identifies the structure. */
+	__u8 bar;		/* Where to find it. */
+	__u8 id;		/* Multiple capabilities of the same type */
+	__u8 padding[2];	/* Pad to full dword. */
+	__le32 offset;		/* Offset within bar. */
+	__le32 length;		/* Length of the structure, in bytes. */
+};
+
+struct virtio_pci_cap64 {
+	struct virtio_pci_cap cap;
+	__le32 offset_hi;             /* Most sig 32 bits of offset */
+	__le32 length_hi;             /* Most sig 32 bits of length */
+};
+
+struct virtio_pci_notify_cap {
+	struct virtio_pci_cap cap;
+	__le32 notify_off_multiplier;	/* Multiplier for queue_notify_off. */
+};
+
+/* Fields in VIRTIO_PCI_CAP_COMMON_CFG: */
+struct virtio_pci_common_cfg {
+	/* About the whole device. */
+	__le32 device_feature_select;	/* read-write */
+	__le32 device_feature;		/* read-only */
+	__le32 guest_feature_select;	/* read-write */
+	__le32 guest_feature;		/* read-write */
+	__le16 msix_config;		/* read-write */
+	__le16 num_queues;		/* read-only */
+	__u8 device_status;		/* read-write */
+	__u8 config_generation;		/* read-only */
+
+	/* About a specific virtqueue. */
+	__le16 queue_select;		/* read-write */
+	__le16 queue_size;		/* read-write, power of 2. */
+	__le16 queue_msix_vector;	/* read-write */
+	__le16 queue_enable;		/* read-write */
+	__le16 queue_notify_off;	/* read-only */
+	__le32 queue_desc_lo;		/* read-write */
+	__le32 queue_desc_hi;		/* read-write */
+	__le32 queue_avail_lo;		/* read-write */
+	__le32 queue_avail_hi;		/* read-write */
+	__le32 queue_used_lo;		/* read-write */
+	__le32 queue_used_hi;		/* read-write */
+};
+
+/* Fields in VIRTIO_PCI_CAP_PCI_CFG: */
+struct virtio_pci_cfg_cap {
+	struct virtio_pci_cap cap;
+	__u8 pci_cfg_data[4]; /* Data for BAR access. */
+};
+
+/* Macro versions of offsets for the Old Timers! */
+#define VIRTIO_PCI_CAP_VNDR		0
+#define VIRTIO_PCI_CAP_NEXT		1
+#define VIRTIO_PCI_CAP_LEN		2
+#define VIRTIO_PCI_CAP_CFG_TYPE		3
+#define VIRTIO_PCI_CAP_BAR		4
+#define VIRTIO_PCI_CAP_OFFSET		8
+#define VIRTIO_PCI_CAP_LENGTH		12
+
+#define VIRTIO_PCI_NOTIFY_CAP_MULT	16
+
+#define VIRTIO_PCI_COMMON_DFSELECT	0
+#define VIRTIO_PCI_COMMON_DF		4
+#define VIRTIO_PCI_COMMON_GFSELECT	8
+#define VIRTIO_PCI_COMMON_GF		12
+#define VIRTIO_PCI_COMMON_MSIX		16
+#define VIRTIO_PCI_COMMON_NUMQ		18
+#define VIRTIO_PCI_COMMON_STATUS	20
+#define VIRTIO_PCI_COMMON_CFGGENERATION	21
+#define VIRTIO_PCI_COMMON_Q_SELECT	22
+#define VIRTIO_PCI_COMMON_Q_SIZE	24
+#define VIRTIO_PCI_COMMON_Q_MSIX	26
+#define VIRTIO_PCI_COMMON_Q_ENABLE	28
+#define VIRTIO_PCI_COMMON_Q_NOFF	30
+#define VIRTIO_PCI_COMMON_Q_DESCLO	32
+#define VIRTIO_PCI_COMMON_Q_DESCHI	36
+#define VIRTIO_PCI_COMMON_Q_AVAILLO	40
+#define VIRTIO_PCI_COMMON_Q_AVAILHI	44
+#define VIRTIO_PCI_COMMON_Q_USEDLO	48
+#define VIRTIO_PCI_COMMON_Q_USEDHI	52
+#define VIRTIO_PCI_COMMON_Q_NDATA	56
+#define VIRTIO_PCI_COMMON_Q_RESET	58
+
+#endif /* VIRTIO_PCI_NO_MODERN */
+
+#endif

--- a/include/pci.h
+++ b/include/pci.h
@@ -1,0 +1,91 @@
+/*  
+ * Copyright (c) 2012, Citrix Systems Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef  _PCI_H
+#define  _PCI_H
+
+#include <linux/pci_regs.h>
+#include <kvm/pci.h>
+#include <xenctrl.h>
+#include <xendevicemodel.h>
+
+#define PCI_VENDOR_ID_REDHAT_QUMRANET		0x1af4 
+#define PCI_SUBSYSTEM_VENDOR_ID_REDHAT_QUMRANET 0x1af4
+#define PCI_DEVICE_ID_VIRTIO_BASE          0x1040
+#define PCI_SUBSYS_ID_VIRTIO_BASE          0x0040
+#define PCI_HEADER_TYPE_NORMAL			0
+
+#define PCI_NUM_BAR             6
+#define PCI_CONFIG_HEADER_SIZE  0x40
+#define PCI_CONFIG_SIZE         0x100
+#define PCI_BAR_UNMAPPED        (~(0u))
+#define PCI_CAP_OFF		PCI_CONFIG_HEADER_SIZE
+
+typedef struct pci_info {
+        uint8_t bus;
+        uint8_t device:5;
+        uint8_t function:3;
+        uint16_t vendor_id;
+        uint16_t device_id;
+        uint16_t command;
+        uint16_t status;
+        uint16_t subvendor_id;
+        uint16_t subdevice_id;
+        uint8_t revision;
+        int class;
+        uint8_t subclass;
+        uint8_t prog_if;
+        uint8_t header_type;
+        uint8_t interrupt_pin;
+        uint8_t interrupt_line;
+        struct virtio_caps virtio;
+} pci_info_t;
+
+int pci_device_register(const pci_info_t *info);
+void pci_device_deregister(void);
+
+typedef struct bar_ops {
+        void (*map)(void *priv, uint64_t addr);
+        void (*unmap)(void *priv);
+        uint8_t (*readb)(void *priv, uint64_t offset);
+        uint16_t (*readw)(void *priv, uint64_t offset);
+        uint32_t (*readl)(void *priv, uint64_t offset);
+        void (*writeb)(void *priv, uint64_t offset, uint8_t val);
+        void (*writew)(void *priv, uint64_t offset, uint16_t val);
+        void (*writel)(void *priv, uint64_t offset, uint32_t val);
+} bar_ops_t;
+
+int pci_bar_register(unsigned int index, uint8_t type, unsigned int order,
+                     const bar_ops_t *ops, void *priv);
+void pci_bar_deregister(unsigned int index);
+uint32_t pci_config_read(uint64_t offset, uint64_t size);
+void pci_config_write(uint64_t offset, uint64_t size, uint32_t val);
+void pci_config_dump();
+
+#endif  /* _PCI_H */
+

--- a/include/virtio-pci.h
+++ b/include/virtio-pci.h
@@ -1,0 +1,117 @@
+/*  
+ * Copyright (c) 2012, Citrix Systems Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef  _DEVICE_H
+#define  _DEVICE_H
+
+#include "demu.h"
+#include <err.h>
+#include "kvm/virtio.h"
+#include <xenctrl.h>
+#include <xendevicemodel.h>
+
+#define VIRTIO_PCI_MAX_VQ	32
+#define VIRTIO_PCI_MAX_CONFIG	1
+
+#define ALIGN_UP(x, s)		ALIGN((x) + (s) - 1, (s))
+#define VIRTIO_NR_MSIX		(VIRTIO_PCI_MAX_VQ + VIRTIO_PCI_MAX_CONFIG)
+#define VIRTIO_MSIX_TABLE_SIZE	(VIRTIO_NR_MSIX * 16)
+#define VIRTIO_MSIX_PBA_SIZE	(ALIGN_UP(VIRTIO_MSIX_TABLE_SIZE, 64) / 8)
+#define VIRTIO_MSIX_BAR_SIZE	(1UL << fls_long(VIRTIO_MSIX_TABLE_SIZE + \
+						 VIRTIO_MSIX_PBA_SIZE))
+struct kvm;
+
+struct virtio_pci {
+/*	struct pci_device_header pci_hdr;*/
+/*	struct device_header	dev_hdr;*/
+	u32			cfg_base;
+	void			*dev;
+	struct kvm		*kvm;
+
+	u32			doorbell_offset;
+	bool			signal_msi;
+	u8			status;
+	u8			isr;
+	u32			device_features_sel;
+	u32			driver_features_sel;
+
+	/*
+	 * We cannot rely on the INTERRUPT_LINE byte in the config space once
+	 * we have run guest code, as the OS is allowed to use that field
+	 * as a scratch pad to communicate between driver and PCI layer.
+	 * So store our legacy interrupt line number in here for internal use.
+	 */
+	u8			legacy_irq_line;
+
+	/* MSI-X */
+	u16			config_vector;
+	u32			config_gsi;
+	u16			vq_vector[VIRTIO_PCI_MAX_VQ];
+	u32			gsis[VIRTIO_PCI_MAX_VQ];
+	u64			msix_pba;
+	/* struct msix_table	msix_table[VIRTIO_PCI_MAX_VQ + VIRTIO_PCI_MAX_CONFIG]; */
+
+	/* virtio queue */
+	u16			queue_selector;
+	/* struct virtio_pci_ioevent_param ioeventfds[VIRTIO_PCI_MAX_VQ]; */
+};
+
+struct kvm_cpu {
+};
+
+static inline u32 virtio_pci__mmio_addr(struct virtio_pci *vpci)
+{
+    return 0;
+}
+
+static void inline kvm__irq_line(struct kvm *kvm, int irq, int level)
+{
+    demu_set_irq(irq, level);
+}
+
+static inline int virtio_pci__add_msix_route(struct virtio_pci *vpci, u32 vec)
+{
+    warn("%s NOT implemented\n", __func__);
+    return -1;
+}
+
+int virtio_pci_init(struct kvm *kvm, void *dev, struct virtio_device *vdev,
+		    int device_id, int subsys_id, int class, u32 addr, u32 irq);
+
+int virtio_pci_exit(struct kvm *kvm, struct virtio_device *vdev);
+int virtio_pci_reset(struct kvm *kvm, struct virtio_device *vdev);
+int virtio_pci_init_vq(struct kvm *kvm, struct virtio_device *vdev, int vq);
+void virtio_pci_exit_vq(struct kvm *kvm, struct virtio_device *vdev, int vq);
+int virtio_pci_signal_vq(struct kvm *kvm, struct virtio_device *vdev, u32 vq);
+int virtio_pci_signal_config(struct kvm *kvm, struct virtio_device *vdev);
+
+void virtio_pci_modern__io_mmio_callback(struct kvm_cpu *vcpu, u64 addr,
+                                         u8 *data, u32 len, u8 is_write,
+                                         void *ptr);
+#endif  /* _DEVICE_H */
+

--- a/pci.c
+++ b/pci.c
@@ -1,0 +1,442 @@
+/*  
+ * Copyright (c) 2012, Citrix Systems Inc.
+ * Copyright (C) 2024 EPAM Systems Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <assert.h>
+#include "debug.h"
+#include <demu.h>
+#include <err.h>
+#include <errno.h>
+#include "pci.h"
+#include <string.h>
+
+#define FALSE 0
+
+typedef struct pci_bar {
+    const bar_ops_t *ops;
+    int is_mmio;
+    int enable;
+    uint32_t addr;
+    uint32_t size;
+    void *priv;
+} pci_bar_t;
+
+typedef struct pci {
+    uint16_t bdf;
+    uint8_t config[PCI_CONFIG_SIZE];
+    uint8_t mask[PCI_CONFIG_SIZE];
+    pci_bar_t bar[PCI_NUM_BAR];
+} pci_t;
+
+static pci_t pci;
+static void pci_update_bar(unsigned int index);
+
+int pci_device_register(const pci_info_t *info)
+{
+    if (info->bus & ~0xff ||
+        info->device & ~0x1f ||
+        info->function & ~0x07)
+    {
+        warnx("bad BDF");
+        return -EINVAL;
+    }
+
+    pci.bdf = (info->bus << 8) | (info->device << 3) | (info->function);
+
+    *(uint16_t *)&pci.config[PCI_VENDOR_ID] = info->vendor_id;
+    *(uint16_t *)&pci.config[PCI_DEVICE_ID] = info->device_id;
+    *(uint16_t *)&pci.config[PCI_STATUS] = info->status;
+    pci.config[PCI_REVISION_ID] = info->revision;
+    pci.config[PCI_CLASS_PROG] = info->prog_if;
+    pci.config[PCI_CLASS_DEVICE + 1] = info->class;
+    pci.config[PCI_CLASS_DEVICE] = info->subclass;
+    pci.config[PCI_HEADER_TYPE] = info->header_type;
+    *(uint16_t *)&pci.config[PCI_SUBSYSTEM_VENDOR_ID] = info->subvendor_id;
+    *(uint16_t *)&pci.config[PCI_SUBSYSTEM_ID] = info->subdevice_id;
+    *(uint16_t *)&pci.config[PCI_COMMAND] = info->command;
+    pci.config[PCI_INTERRUPT_PIN] = info->interrupt_pin;
+
+    pci.mask[PCI_CACHE_LINE_SIZE] = 0xff;
+    pci.mask[PCI_INTERRUPT_LINE] = info->interrupt_line;
+    *(uint16_t *)&pci.mask[PCI_COMMAND] = PCI_COMMAND_IO |
+                                          PCI_COMMAND_MEMORY |
+                                          PCI_COMMAND_MASTER |
+                                          PCI_COMMAND_INTX_DISABLE;
+    memset(&pci.mask[PCI_CONFIG_HEADER_SIZE], 0xff,
+           PCI_CONFIG_SIZE - PCI_CONFIG_HEADER_SIZE);
+
+    pci.config[PCI_CAPABILITY_LIST] = PCI_CAP_OFF;
+    memcpy(&pci.config[PCI_CAP_OFF], &info->virtio, sizeof(struct virtio_caps));
+
+    return demu_register_pcidev(info->bus, info->device, info->function);
+}
+
+void
+pci_device_deregister(void)
+{
+    uint8_t bus = (pci.bdf >> 8) & 0xff;
+    uint8_t device = (pci.bdf >> 3) & 0x1f;
+    uint8_t function = pci.bdf & 0x07;
+
+    demu_deregister_pcidev(bus, device, function);
+ }
+
+int
+pci_bar_register(unsigned int index, uint8_t type, unsigned int order,
+                 const bar_ops_t *ops, void *priv)
+{
+    pci_bar_t *bar;
+
+    DBG("%d: %08x\n", index, 1u << order);
+
+    if (index >= PCI_NUM_BAR) {
+        warnx("unsupported BAR index %d", index);
+        return -EINVAL;
+    }
+
+    bar = &pci.bar[index];
+
+    if (bar->enable) {
+        warnx("BAR%d busy", index);
+        return -EBUSY;
+    }
+
+    if (ops == NULL ||
+        ops->readb == NULL ||
+        ops->writeb == NULL)
+    {
+        return -EFAULT;
+    }
+
+    bar->ops = ops;
+    bar->is_mmio = !(type & PCI_BASE_ADDRESS_SPACE_IO);
+    bar->size = 1u << order;
+
+    *(uint32_t *)&pci.config[PCI_BASE_ADDRESS_0 + (index * 4)] = type;
+    *(uint32_t *)&pci.mask[PCI_BASE_ADDRESS_0 + (index * 4)] =
+        ~(bar->size - 1);
+
+    bar->enable = 1;
+    bar->addr = PCI_BAR_UNMAPPED;
+
+    bar->priv = priv;
+
+    return 0;
+}
+
+void
+pci_bar_deregister(unsigned int index)
+{
+    pci_bar_t *bar = &pci.bar[index];
+
+    DBG("%d\n", index);
+
+    bar->addr = PCI_BAR_UNMAPPED;
+    bar->priv = NULL;
+    bar->enable = 0;
+    bar->ops = NULL;
+}
+
+static pci_bar_t *
+pci_bar_get(int is_mmio, uint64_t addr)
+{
+    int i;
+
+    for (i = 0; i < PCI_NUM_BAR; i++)
+    {
+        pci_bar_t *bar = &pci.bar[i];
+
+        if (!bar->enable || bar->is_mmio != is_mmio)
+            continue;
+
+        if (bar->addr <= addr && addr < (bar->addr + bar->size))
+            return bar;
+    }
+
+    return NULL;
+}
+
+#define PCI_BAR_READ(_fn, _priv, _addr, _size, _count, _val)    \
+do {                                                            \
+    int             _i = 0;                                     \
+    unsigned int    _shift = 0;                                 \
+                                                                \
+    (_val) = 0;                                                 \
+    for (_i = 0; _i < (_count); _i++)                           \
+    {                                                           \
+        (_val) |= (_fn)((_priv), (_addr)) << _shift;            \
+        _shift += 8 * (_size);                                  \
+        (_addr) += (_size);                                     \
+    }                                                           \
+} while (FALSE)
+
+static uint32_t
+pci_bar_read(int is_mmio, uint64_t addr, uint64_t size)
+{
+    pci_bar_t *bar = pci_bar_get(is_mmio, addr);
+    uint32_t val = 0;
+
+    assert(bar != NULL);
+    if (!bar)
+       return 0;
+
+    addr -= bar->addr;
+
+    switch (size) {
+    case 1:
+        val = bar->ops->readb(bar->priv, addr);
+        break;
+
+    case 2:
+        if (bar->ops->readw == NULL)
+            PCI_BAR_READ(bar->ops->readb, bar->priv, addr, 1, 2, val);
+        else
+            val = bar->ops->readw(bar->priv, addr);
+        break;
+
+    case 4:
+        if (bar->ops->readl == NULL) {
+            if (bar->ops->readw == NULL)
+                PCI_BAR_READ(bar->ops->readb, bar->priv, addr, 1, 4, val);
+            else
+                PCI_BAR_READ(bar->ops->readw, bar->priv, addr, 2, 2, val);
+        } else {
+            val = bar->ops->readl(bar->priv, addr);
+        }
+        break;
+
+    default:
+        assert(FALSE);
+    }
+
+    return val;
+}
+
+#define PCI_BAR_WRITE(_fn, _priv, _addr, _size, _count, _val)   \
+do {                                                            \
+    int _i = 0;                                                 \
+    unsigned int _shift = 0;                                    \
+                                                                \
+    (_val) = 0;                                                 \
+    for (_i = 0; _i < (_count); _i++)                           \
+    {                                                           \
+        (_fn)((_priv), (_addr), (_val) >> _shift);              \
+        _shift += 8 * (_size);                                  \
+        (_addr) += (_size);                                     \
+    }                                                           \
+} while (FALSE)
+
+static void
+pci_bar_write(int is_mmio, uint64_t addr, uint64_t size, uint32_t val)
+{
+    pci_bar_t *bar = pci_bar_get(is_mmio, addr);
+
+    assert(bar != NULL);
+    addr -= bar->addr;
+
+    switch (size) {
+    case 1:
+        bar->ops->writeb(bar->priv, addr, val);
+        break;
+
+    case 2:
+        if (bar->ops->writew == NULL)
+            PCI_BAR_WRITE(bar->ops->writeb, bar->priv, addr, 1, 2, val);
+        else
+            bar->ops->writew(bar->priv, addr, val);
+        break;
+
+    case 4:
+        if (bar->ops->writel == NULL) {
+            if (bar->ops->writew == NULL)
+                PCI_BAR_WRITE(bar->ops->writeb, bar->priv, addr, 1, 4, val);
+            else
+                PCI_BAR_WRITE(bar->ops->writew, bar->priv, addr, 2, 2, val);
+        } else {
+            bar->ops->writel(bar->priv, addr, val);
+        }
+        break;
+
+    default:
+        assert(FALSE);
+    }
+}
+
+static void pci_mmio_callback(u64 addr, u8 *data,
+                              u32 len, u8 is_write, void *ptr)
+{
+    pci_bar_t *bar = ptr;
+
+/*    DBG("%s %llx size=%u\n", is_write ? "write" : "read", addr, len); */
+    if (is_write)
+        pci_bar_write(bar->is_mmio, addr, len, *((uint32_t*)data));
+    else
+       *((uint32_t*)data) = pci_bar_read(bar->is_mmio, addr, len);
+}
+
+static void
+pci_map_bar(unsigned int index)
+{
+    pci_bar_t *bar = &pci.bar[index];
+
+    DBG("%d: %08x\n", index, bar->addr);
+
+    if (bar->ops->map)
+        bar->ops->map(bar->priv, bar->addr);
+
+    demu_register_memory_space(bar->addr, bar->size,
+                               pci_mmio_callback, bar);
+}
+
+static void
+pci_unmap_bar(unsigned int index)
+{
+    pci_bar_t *bar = &pci.bar[index];
+
+    DBG("%d\n", index);
+
+    (void) demu_deregister_memory_space(bar->addr);
+
+    if (bar->ops->unmap)
+        bar->ops->unmap(bar->priv);
+}
+
+static void
+pci_update_bar(unsigned int index)
+{
+    pci_bar_t *bar = &pci.bar[index];
+    uint32_t addr = *(uint32_t *)&pci.config[PCI_BASE_ADDRESS_0 +
+                                             (index * 4)];
+    uint16_t cmd = *(uint16_t *)&pci.config[PCI_COMMAND];
+    uint32_t mask = ~(bar->size - 1);
+
+    if (!bar->enable)
+        return;
+
+    if (bar->is_mmio)
+        addr &= PCI_BASE_ADDRESS_MEM_MASK;
+    else
+        addr &= PCI_BASE_ADDRESS_IO_MASK;
+
+    if ((!(cmd & PCI_COMMAND_IO) && !bar->is_mmio)
+        || (!(cmd & PCI_COMMAND_MEMORY) && bar->is_mmio))
+        addr = PCI_BAR_UNMAPPED;
+
+    if (addr == 0 || addr == mask)
+        addr = PCI_BAR_UNMAPPED;
+
+    if (bar->addr == addr)
+        return;
+
+    if (bar->addr != PCI_BAR_UNMAPPED) {
+        pci_unmap_bar(index);
+        bar->addr = PCI_BAR_UNMAPPED;
+    }
+
+    if (addr != PCI_BAR_UNMAPPED) {
+        bar->addr = addr;
+        pci_map_bar(index);
+    }
+}
+
+void
+pci_update_config()
+{
+    int i;
+
+    for (i = 0; i < PCI_NUM_BAR; i++)
+        pci_update_bar(i);
+}
+
+uint32_t
+pci_config_read(uint64_t offset, uint64_t size)
+{
+    uint64_t i;
+    uint32_t val = 0;
+
+    offset &= 0xff;
+
+    for (i = 0; i < size; i++) {
+        if ((offset + i) < PCI_CONFIG_SIZE)
+            val |= (uint32_t)pci.config[offset + i] << (i * 8);
+        else
+            val |= (uint32_t)0xff << (i + 8);
+    }
+
+    return val;
+}
+
+void
+pci_config_write(uint64_t offset, uint64_t size, uint32_t val)
+{
+    uint64_t i;
+    uint8_t mask;
+
+    offset &= 0xff;
+    offset += size >> 16;
+    size &= 0xffff;
+
+    for (i = 0; i < size; i++) {
+        if ((offset + i) < PCI_CONFIG_SIZE) {
+            mask = pci.mask[offset + i];
+            pci.config[offset + i] &= ~mask;
+            pci.config[offset + i] |= (uint8_t)(val >> (i * 8)) & mask;
+
+        }
+    }
+
+    pci_update_config();
+}
+
+void
+pci_config_dump(void)
+{
+    int i;
+
+    fprintf(stderr, "    3  2  1  0\n");
+    fprintf(stderr, "--------------\n");
+
+    for (i = 0; i < PCI_CONFIG_HEADER_SIZE; i += 4) {
+        fprintf(stderr, "%02x |%02x %02x %02x %02x\n",
+                i,
+                pci.config[i + 3],
+                pci.config[i + 2],
+                pci.config[i + 1],
+                pci.config[i ]);
+    }
+}
+
+/*
+ * Local variables:
+ * mode: C
+ * c-file-style: "BSD"
+ * c-basic-offset: 4
+ * c-tab-always-indent: nil
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/virtio/core.c
+++ b/virtio/core.c
@@ -8,6 +8,7 @@
 #include "kvm/virtio-mmio.h"
 #include "kvm/util.h"
 #include "kvm/kvm.h"
+#include "virtio-pci.h"
 
 #include "../demu.h"
 
@@ -421,6 +422,20 @@ int virtio_init(struct kvm *kvm, void *dev, struct virtio_device *vdev,
 		vdev->ops->reset		= virtio_mmio_reset;
 		r = vdev->ops->init(kvm, dev, vdev, device_id, subsys_id, class, addr, irq);
 		break;
+	case VIRTIO_PCI:
+		virtio = calloc(sizeof(struct virtio_pci), 1);
+		if (!virtio)
+			return -ENOMEM;
+		vdev->virtio			= virtio;
+		vdev->ops			= ops;
+		vdev->ops->signal_vq		= virtio_pci_signal_vq;
+		vdev->ops->signal_config	= virtio_pci_signal_config;
+		vdev->ops->init			= virtio_pci_init;
+		vdev->ops->exit			= virtio_pci_exit;
+		vdev->ops->reset		= virtio_pci_reset;
+		r = vdev->ops->init(kvm, dev, vdev, device_id, subsys_id, class, addr, irq);
+		break;
+
 	default:
 		r = -1;
 	};

--- a/virtio/pci-modern.c
+++ b/virtio/pci-modern.c
@@ -1,0 +1,394 @@
+#include "virtio-pci.h"
+
+#include "kvm/ioport.h"
+#include "kvm/virtio.h"
+#include "kvm/pci.h"
+
+#include <linux/virtio_config.h>
+
+#define VPCI_CFG_COMMON_SIZE	sizeof(struct virtio_pci_common_cfg)
+#define VPCI_CFG_COMMON_START	0
+#define VPCI_CFG_COMMON_END	(VPCI_CFG_COMMON_SIZE - 1)
+/*
+ * Use a naturally aligned 4-byte doorbell, in case we ever want to
+ * implement VIRTIO_F_NOTIFICATION_DATA
+ */
+#define VPCI_CFG_NOTIFY_SIZE	4
+#define VPCI_CFG_NOTIFY_START	(VPCI_CFG_COMMON_END + 1)
+#define VPCI_CFG_NOTIFY_END	(VPCI_CFG_COMMON_END + VPCI_CFG_NOTIFY_SIZE)
+#define VPCI_CFG_ISR_SIZE	4
+#define VPCI_CFG_ISR_START	(VPCI_CFG_NOTIFY_END + 1)
+#define VPCI_CFG_ISR_END	(VPCI_CFG_NOTIFY_END + VPCI_CFG_ISR_SIZE)
+/*
+ * We're at 64 bytes. Use the remaining 192 bytes in PCI_IO_SIZE for the
+ * device-specific config space. It's sufficient for the devices we
+ * currently implement (virtio_blk_config is 60 bytes) and, I think, all
+ * existing virtio 1.2 devices.
+ */
+#define VPCI_CFG_DEV_START	(VPCI_CFG_ISR_END + 1)
+#define VPCI_CFG_DEV_END	((PCI_IO_SIZE) - 1)
+#define VPCI_CFG_DEV_SIZE	(VPCI_CFG_DEV_END - VPCI_CFG_DEV_START + 1)
+
+#define vpci_selected_vq(vpci) \
+	vdev->ops->get_vq((vpci)->kvm, (vpci)->dev, (vpci)->queue_selector)
+
+typedef bool (*access_handler_t)(struct virtio_device *, unsigned long, void *, int);
+
+static bool virtio_pci__common_write(struct virtio_device *vdev,
+				     unsigned long offset, void *data, int size)
+{
+	u64 features;
+	u32 val, gsi, vec;
+	struct virtio_pci *vpci = vdev->virtio;
+
+	switch (offset - VPCI_CFG_COMMON_START) {
+	case VIRTIO_PCI_COMMON_DFSELECT:
+		vpci->device_features_sel = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_GFSELECT:
+		vpci->driver_features_sel = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_GF:
+		val = ioport__read32(data);
+		if (vpci->driver_features_sel > 1)
+			break;
+
+		features = (u64)val << (32 * vpci->driver_features_sel);
+		virtio_set_guest_features(vpci->kvm, vdev, vpci->dev, features);
+		break;
+	case VIRTIO_PCI_COMMON_MSIX:
+		vec = vpci->config_vector = ioport__read16(data);
+		gsi = virtio_pci__add_msix_route(vpci, vec);
+		if (gsi < 0)
+			break;
+
+		vpci->config_gsi = gsi;
+		break;
+	case VIRTIO_PCI_COMMON_STATUS:
+		vpci->status = ioport__read8(data);
+		virtio_notify_status(vpci->kvm, vdev, vpci->dev, vpci->status);
+		break;
+	case VIRTIO_PCI_COMMON_Q_SELECT:
+		val = ioport__read16(data);
+		if (val >= (u32)vdev->ops->get_vq_count(vpci->kvm, vpci->dev))
+			pr_warning("invalid vq number %u", val);
+		else
+			vpci->queue_selector = val;
+		break;
+	case VIRTIO_PCI_COMMON_Q_SIZE:
+		vdev->ops->set_size_vq(vpci->kvm, vpci->dev,
+				       vpci->queue_selector,
+				       ioport__read16(data));
+		break;
+	case VIRTIO_PCI_COMMON_Q_MSIX:
+		vec = vpci->vq_vector[vpci->queue_selector] = ioport__read16(data);
+
+		gsi = virtio_pci__add_msix_route(vpci, vec);
+		if (gsi < 0)
+			break;
+
+		vpci->gsis[vpci->queue_selector] = gsi;
+		if (vdev->ops->notify_vq_gsi)
+			vdev->ops->notify_vq_gsi(vpci->kvm, vpci->dev,
+						 vpci->queue_selector, gsi);
+		break;
+	case VIRTIO_PCI_COMMON_Q_ENABLE:
+		val = ioport__read16(data);
+		if (val)
+			virtio_pci_init_vq(vpci->kvm, vdev, vpci->queue_selector);
+		else
+			virtio_pci_exit_vq(vpci->kvm, vdev, vpci->queue_selector);
+		break;
+	case VIRTIO_PCI_COMMON_Q_DESCLO:
+		vpci_selected_vq(vpci)->vring_addr.desc_lo = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_Q_DESCHI:
+		vpci_selected_vq(vpci)->vring_addr.desc_hi = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_Q_AVAILLO:
+		vpci_selected_vq(vpci)->vring_addr.avail_lo = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_Q_AVAILHI:
+		vpci_selected_vq(vpci)->vring_addr.avail_hi = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_Q_USEDLO:
+		vpci_selected_vq(vpci)->vring_addr.used_lo = ioport__read32(data);
+		break;
+	case VIRTIO_PCI_COMMON_Q_USEDHI:
+		vpci_selected_vq(vpci)->vring_addr.used_hi = ioport__read32(data);
+		break;
+	}
+
+	return true;
+}
+
+static bool virtio_pci__notify_write(struct virtio_device *vdev,
+				     unsigned long offset, void *data, int size)
+{
+	u16 vq = ioport__read16(data);
+	struct virtio_pci *vpci = vdev->virtio;
+
+	vdev->ops->notify_vq(vpci->kvm, vpci->dev, vq);
+
+	return true;
+}
+
+static bool virtio_pci__config_write(struct virtio_device *vdev,
+				     unsigned long offset, void *data, int size)
+{
+	struct virtio_pci *vpci = vdev->virtio;
+#if 0
+	return virtio_access_config(vpci->kvm, vdev, vpci->dev,
+				    offset - VPCI_CFG_DEV_START, data, size,
+				    true);
+#endif
+	return virtio_write_config(vpci->kvm, vdev, vpci->dev,
+				   offset - VPCI_CFG_DEV_START, data, size);
+}
+
+static bool virtio_pci__common_read(struct virtio_device *vdev,
+				    unsigned long offset, void *data, int size)
+{
+	u32 val;
+	struct virtio_pci *vpci = vdev->virtio;
+	u64 features = 1ULL << VIRTIO_F_VERSION_1;
+
+	switch (offset - VPCI_CFG_COMMON_START) {
+	case VIRTIO_PCI_COMMON_DFSELECT:
+		val = vpci->device_features_sel;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_DF:
+		if (vpci->device_features_sel > 1)
+			break;
+		features |= vdev->ops->get_host_features(vpci->kvm, vpci->dev);
+		val = features >> (32 * vpci->device_features_sel);
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_GFSELECT:
+		val = vpci->driver_features_sel;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_MSIX:
+		val = vpci->config_vector;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_NUMQ:
+		val = vdev->ops->get_vq_count(vpci->kvm, vpci->dev);
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_STATUS:
+		ioport__write8(data, vpci->status);
+		break;
+	case VIRTIO_PCI_COMMON_CFGGENERATION:
+		/*
+		 * The config generation changes when the device updates a
+		 * config field larger than 32 bits, that the driver may read
+		 * using multiple accesses. Since kvmtool doesn't use any
+		 * mutable config field larger than 32 bits, the generation is
+		 * constant.
+		 */
+		ioport__write8(data, 0);
+		break;
+	case VIRTIO_PCI_COMMON_Q_SELECT:
+		ioport__write16(data, vpci->queue_selector);
+		break;
+	case VIRTIO_PCI_COMMON_Q_SIZE:
+		val = vdev->ops->get_size_vq(vpci->kvm, vpci->dev,
+					     vpci->queue_selector);
+		ioport__write16(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_MSIX:
+		val = vpci->vq_vector[vpci->queue_selector];
+		ioport__write16(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_ENABLE:
+		val = vpci_selected_vq(vpci)->enabled;
+		ioport__write16(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_NOFF:
+		val = vpci->queue_selector;
+		ioport__write16(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_DESCLO:
+		val = vpci_selected_vq(vpci)->vring_addr.desc_lo;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_DESCHI:
+		val = vpci_selected_vq(vpci)->vring_addr.desc_hi;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_AVAILLO:
+		val = vpci_selected_vq(vpci)->vring_addr.avail_lo;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_AVAILHI:
+		val = vpci_selected_vq(vpci)->vring_addr.avail_hi;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_USEDLO:
+		val = vpci_selected_vq(vpci)->vring_addr.used_lo;
+		ioport__write32(data, val);
+		break;
+	case VIRTIO_PCI_COMMON_Q_USEDHI:
+		val = vpci_selected_vq(vpci)->vring_addr.used_hi;
+		ioport__write32(data, val);
+		break;
+	};
+
+	return true;
+}
+
+static bool virtio_pci__isr_read(struct virtio_device *vdev,
+				 unsigned long offset, void *data, int size)
+{
+	struct virtio_pci *vpci = vdev->virtio;
+
+	if (WARN_ON(offset - VPCI_CFG_ISR_START != 0))
+		return false;
+
+	ioport__write8(data, vpci->isr);
+	kvm__irq_line(vpci->kvm, vpci->legacy_irq_line, VIRTIO_IRQ_LOW);
+	vpci->isr = 0;
+
+	return 0;
+}
+
+static bool virtio_pci__config_read(struct virtio_device *vdev,
+				    unsigned long offset, void *data, int size)
+{
+	struct virtio_pci *vpci = vdev->virtio;
+#if 0
+	return virtio_access_config(vpci->kvm, vdev, vpci->dev,
+				    offset - VPCI_CFG_DEV_START, data, size,
+				    false);
+#endif
+	return virtio_read_config(vpci->kvm, vdev, vpci->dev,
+				  offset - VPCI_CFG_DEV_START, data, size);
+}
+
+static bool virtio_pci_access(struct kvm_cpu *vcpu, struct virtio_device *vdev,
+			      unsigned long offset, void *data, int size,
+			      bool write)
+{
+	access_handler_t handler = NULL;
+
+	switch (offset) {
+	case VPCI_CFG_COMMON_START...VPCI_CFG_COMMON_END:
+		if (write)
+			handler = virtio_pci__common_write;
+		else
+			handler = virtio_pci__common_read;
+		break;
+	case VPCI_CFG_NOTIFY_START...VPCI_CFG_NOTIFY_END:
+		if (write)
+			handler = virtio_pci__notify_write;
+		break;
+	case VPCI_CFG_ISR_START...VPCI_CFG_ISR_END:
+		if (!write)
+			handler = virtio_pci__isr_read;
+		break;
+	case VPCI_CFG_DEV_START...VPCI_CFG_DEV_END:
+		if (write)
+			handler = virtio_pci__config_write;
+		else
+			handler = virtio_pci__config_read;
+		break;
+	}
+
+	if (!handler)
+		return false;
+
+	return handler(vdev, offset, data, size);
+}
+
+void virtio_pci_modern__io_mmio_callback(struct kvm_cpu *vcpu, u64 addr,
+					 u8 *data, u32 len, u8 is_write,
+					 void *ptr)
+{
+	struct virtio_device *vdev = ptr;
+	struct virtio_pci *vpci = vdev->virtio;
+	u32 mmio_addr = virtio_pci__mmio_addr(vpci);
+
+	virtio_pci_access(vcpu, vdev, addr - mmio_addr, data, len, is_write);
+}
+#if 0
+int virtio_pci_modern_init(struct virtio_device *vdev)
+{
+	int subsys_id;
+	struct virtio_pci *vpci = vdev->virtio;
+	struct pci_device_header *hdr = &vpci->pci_hdr;
+
+	subsys_id = le16_to_cpu(hdr->subsys_id);
+
+	hdr->device_id = cpu_to_le16(PCI_DEVICE_ID_VIRTIO_BASE + subsys_id);
+	hdr->subsys_id = cpu_to_le16(PCI_SUBSYS_ID_VIRTIO_BASE + subsys_id);
+
+	vpci->doorbell_offset = VPCI_CFG_NOTIFY_START;
+	vdev->endian = VIRTIO_ENDIAN_LE;
+
+	hdr->msix.next = PCI_CAP_OFF(hdr, virtio);
+
+	hdr->virtio.common = (struct virtio_pci_cap) {
+		.cap_vndr		= PCI_CAP_ID_VNDR,
+		.cap_next		= PCI_CAP_OFF(hdr, virtio.notify),
+		.cap_len		= sizeof(hdr->virtio.common),
+		.cfg_type		= VIRTIO_PCI_CAP_COMMON_CFG,
+		.bar			= 1,
+		.offset			= cpu_to_le32(VPCI_CFG_COMMON_START),
+		.length			= cpu_to_le32(VPCI_CFG_COMMON_SIZE),
+	};
+	BUILD_BUG_ON(VPCI_CFG_COMMON_START & 0x3);
+
+	hdr->virtio.notify = (struct virtio_pci_notify_cap) {
+		.cap.cap_vndr		= PCI_CAP_ID_VNDR,
+		.cap.cap_next		= PCI_CAP_OFF(hdr, virtio.isr),
+		.cap.cap_len		= sizeof(hdr->virtio.notify),
+		.cap.cfg_type		= VIRTIO_PCI_CAP_NOTIFY_CFG,
+		.cap.bar		= 1,
+		.cap.offset		= cpu_to_le32(VPCI_CFG_NOTIFY_START),
+		.cap.length		= cpu_to_le32(VPCI_CFG_NOTIFY_SIZE),
+		/*
+		 * Notify multiplier is 0, meaning that notifications are all on
+		 * the same register
+		 */
+	};
+	BUILD_BUG_ON(VPCI_CFG_NOTIFY_START & 0x3);
+
+	hdr->virtio.isr = (struct virtio_pci_cap) {
+		.cap_vndr		= PCI_CAP_ID_VNDR,
+		.cap_next		= PCI_CAP_OFF(hdr, virtio.device),
+		.cap_len		= sizeof(hdr->virtio.isr),
+		.cfg_type		= VIRTIO_PCI_CAP_ISR_CFG,
+		.bar			= 1,
+		.offset			= cpu_to_le32(VPCI_CFG_ISR_START),
+		.length			= cpu_to_le32(VPCI_CFG_ISR_SIZE),
+	};
+
+	hdr->virtio.device = (struct virtio_pci_cap) {
+		.cap_vndr		= PCI_CAP_ID_VNDR,
+		.cap_next		= PCI_CAP_OFF(hdr, virtio.pci),
+		.cap_len		= sizeof(hdr->virtio.device),
+		.cfg_type		= VIRTIO_PCI_CAP_DEVICE_CFG,
+		.bar			= 1,
+		.offset			= cpu_to_le32(VPCI_CFG_DEV_START),
+		.length			= cpu_to_le32(VPCI_CFG_DEV_SIZE),
+	};
+	BUILD_BUG_ON(VPCI_CFG_DEV_START & 0x3);
+
+	/*
+	 * TODO: implement this weird proxy capability (it is a "MUST" in the
+	 * spec, but I don't know if anyone actually uses it).
+	 * It doesn't use any BAR space. Instead the driver writes .cap.offset
+	 * and .cap.length to access a register in a BAR.
+	 */
+	hdr->virtio.pci = (struct virtio_pci_cfg_cap) {
+		.cap.cap_vndr		= PCI_CAP_ID_VNDR,
+		.cap.cap_next		= 0,
+		.cap.cap_len		= sizeof(hdr->virtio.pci),
+		.cap.cfg_type		= VIRTIO_PCI_CAP_PCI_CFG,
+	};
+
+	return 0;
+}
+#endif

--- a/virtio/pci.c
+++ b/virtio/pci.c
@@ -1,0 +1,312 @@
+/*  
+ * Copyright (c) 2012, Citrix Systems Inc.
+ * Copyright (C) 2024 EPAM Systems Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <debug.h>
+#include <demu.h>
+#include <err.h>
+#include <linux/byteorder.h>
+#include <pci.h>
+#include <virtio-pci.h>
+
+#define VPCI_CFG_COMMON_SIZE	sizeof(struct virtio_pci_common_cfg)
+#define VPCI_CFG_COMMON_START	0
+#define VPCI_CFG_COMMON_END	(VPCI_CFG_COMMON_SIZE - 1)
+/*
+ * Use a naturally aligned 4-byte doorbell, in case we ever want to
+ * implement VIRTIO_F_NOTIFICATION_DATA
+ */
+#define VPCI_CFG_NOTIFY_SIZE	4
+#define VPCI_CFG_NOTIFY_START	(VPCI_CFG_COMMON_END + 1)
+#define VPCI_CFG_NOTIFY_END	(VPCI_CFG_COMMON_END + VPCI_CFG_NOTIFY_SIZE)
+#define VPCI_CFG_ISR_SIZE	4
+#define VPCI_CFG_ISR_START	(VPCI_CFG_NOTIFY_END + 1)
+#define VPCI_CFG_ISR_END	(VPCI_CFG_NOTIFY_END + VPCI_CFG_ISR_SIZE)
+/*
+ * We're at 64 bytes. Use the remaining 192 bytes in PCI_IO_SIZE for the
+ * device-specific config space. It's sufficient for the devices we
+ * currently implement (virtio_blk_config is 60 bytes) and, I think, all
+ * existing virtio 1.2 devices.
+ */
+#define VPCI_CFG_DEV_START	(VPCI_CFG_ISR_END + 1)
+#define VPCI_CFG_DEV_END	((PCI_IO_SIZE) - 1)
+#define VPCI_CFG_DEV_SIZE	(VPCI_CFG_DEV_END - VPCI_CFG_DEV_START + 1)
+
+static uint8_t
+device_memory_readb(void *priv, uint64_t offset)
+{
+    uint32_t res;
+
+    virtio_pci_modern__io_mmio_callback(NULL, offset, (uint8_t *)&res, 1,
+                                        false, priv);
+    /* DBG("off=%lx res=%x\n", offset, res); */
+    return (uint8_t)res;
+}
+
+static uint16_t
+device_memory_readw(void *priv, uint64_t offset)
+{
+    uint32_t res;
+
+    virtio_pci_modern__io_mmio_callback(NULL, offset, (uint8_t *)&res, 2,
+                                        false, priv);
+    /* DBG("off=%lx res=%x\n", offset, res); */
+    return (uint16_t)res;
+}
+
+static uint32_t
+device_memory_readl(void *priv, uint64_t offset)
+{
+    uint32_t res;
+
+    virtio_pci_modern__io_mmio_callback(NULL, offset, (uint8_t *)&res, 4,
+                                        false, priv);
+    /* DBG("off=%lx res=%x\n", offset, res); */
+    return res;
+}
+
+static void
+device_memory_writeb(void *priv, uint64_t offset, uint8_t val)
+{
+    struct kvm_cpu vcpu;
+
+    /* DBG("off=%lx val=0x%x\n", offset, val); */
+    virtio_pci_modern__io_mmio_callback(&vcpu, offset, &val, 1,
+                                        true, priv);
+}
+
+void device_memory_writew(void *priv, uint64_t offset, uint16_t val)
+{
+    struct kvm_cpu vcpu;
+
+    /* DBG("off=%lx val=0x%x\n", offset, val); */
+    virtio_pci_modern__io_mmio_callback(&vcpu, offset, (uint8_t *)&val, 2,
+                                        true, priv);
+}
+
+void device_memory_writel(void *priv, uint64_t offset, uint32_t val)
+{
+    struct kvm_cpu vcpu;
+
+    /* DBG("off=%lx val=0x%x\n", offset, val); */
+    virtio_pci_modern__io_mmio_callback(&vcpu, offset, (uint8_t *)&val, 4,
+                                        true, priv);
+}
+
+static bar_ops_t device_memory_ops = {
+    .readb = device_memory_readb,
+    .readw = device_memory_readw,
+    .readl = device_memory_readl,
+    .writeb = device_memory_writeb,
+    .writew = device_memory_writew,
+    .writel = device_memory_writel,
+};
+
+static void pci_config_mmio_callback(u64 addr, u8 *data,
+				u32 len, u8 is_write, void *ptr)
+{
+    struct virtio_pci *vpci = ptr;
+    uint64_t offset = addr - vpci->cfg_base;
+
+    /* DBG("%s %llx size=%u\n", is_write ? "write" : "read", addr, len); */
+    if (is_write)
+        pci_config_write(offset, len, *((uint32_t*)data));
+    else
+       *((uint32_t*)data) = pci_config_read(offset, len);
+}
+
+int virtio_pci_init(struct kvm *kvm, void *dev, struct virtio_device *vdev,
+		    int device_id, int subsys_id, int class, u32 addr, u32 irq)
+{
+    struct virtio_pci *vpci = vdev->virtio;
+    size_t next_cap_off = PCI_CAP_OFF;
+    pci_info_t info;
+    int rc;
+
+    vpci->cfg_base = addr;
+    vpci->dev = dev;
+    vpci->kvm = kvm;
+    vpci->config_vector = VIRTIO_MSI_NO_VECTOR;
+    memset(vpci->vq_vector, 0xff, sizeof(vpci->vq_vector));
+    vpci->legacy_irq_line = irq;
+
+    /*TODO: shall not be hard-coded */
+    info.bus = 0x0;
+    info.device = 0x3;
+    info.function = 0x0;
+
+    info.vendor_id = cpu_to_le16(PCI_VENDOR_ID_REDHAT_QUMRANET);
+    info.device_id = cpu_to_le16(device_id);
+    info.subvendor_id = cpu_to_le16(PCI_SUBSYSTEM_VENDOR_ID_REDHAT_QUMRANET);
+    info.subdevice_id = cpu_to_le16(subsys_id);
+    info.revision = vdev->legacy ? 0x00 : 0x01,
+    info.prog_if = class & 0xff;
+    info.subclass = (class >> 8) & 0xff;
+    info.class = (class >> 16) & 0xff;
+    info.header_type = PCI_HEADER_TYPE_NORMAL;
+    info.command = PCI_COMMAND_IO | PCI_COMMAND_MEMORY;
+    info.status = cpu_to_le16(PCI_STATUS_CAP_LIST);
+    info.interrupt_pin = 1;
+    info.interrupt_line = irq;
+
+    info.device_id = cpu_to_le16(PCI_DEVICE_ID_VIRTIO_BASE + subsys_id);
+    info.subdevice_id = cpu_to_le16(PCI_SUBSYS_ID_VIRTIO_BASE + subsys_id);
+
+    next_cap_off += sizeof(info.virtio.common);
+    info.virtio.common = (struct virtio_pci_cap) {
+        .cap_vndr = PCI_CAP_ID_VNDR,
+        .cap_next = next_cap_off,
+        .cap_len  = sizeof(info.virtio.common),
+        .cfg_type = VIRTIO_PCI_CAP_COMMON_CFG,
+        .bar      = 1,
+        .offset   = cpu_to_le32(VPCI_CFG_COMMON_START),
+        .length   = cpu_to_le32(VPCI_CFG_COMMON_SIZE),
+	};
+
+    next_cap_off += sizeof(info.virtio.notify);
+    info.virtio.notify = (struct virtio_pci_notify_cap) {
+        .cap.cap_vndr = PCI_CAP_ID_VNDR,
+        .cap.cap_next = next_cap_off,
+        .cap.cap_len  = sizeof(info.virtio.notify),
+        .cap.cfg_type = VIRTIO_PCI_CAP_NOTIFY_CFG,
+        .cap.bar      = 1,
+        .cap.offset   = cpu_to_le32(VPCI_CFG_NOTIFY_START),
+        .cap.length   = cpu_to_le32(VPCI_CFG_NOTIFY_SIZE),
+    };
+
+    next_cap_off += sizeof(info.virtio.isr);
+    info.virtio.isr = (struct virtio_pci_cap) {
+        .cap_vndr = PCI_CAP_ID_VNDR,
+        .cap_next = next_cap_off,
+        .cap_len  = sizeof(info.virtio.isr),
+        .cfg_type = VIRTIO_PCI_CAP_ISR_CFG,
+        .bar      = 1,
+        .offset   = cpu_to_le32(VPCI_CFG_ISR_START),
+        .length   = cpu_to_le32(VPCI_CFG_ISR_SIZE),
+    };
+
+    next_cap_off += sizeof(info.virtio.device);
+    info.virtio.device = (struct virtio_pci_cap) {
+        .cap_vndr = PCI_CAP_ID_VNDR,
+        .cap_next = next_cap_off,
+        .cap_len  = sizeof(info.virtio.device),
+        .cfg_type = VIRTIO_PCI_CAP_DEVICE_CFG,
+        .bar      = 1,
+        .offset   = cpu_to_le32(VPCI_CFG_DEV_START),
+        .length   = cpu_to_le32(VPCI_CFG_DEV_SIZE),
+    };
+
+    info.virtio.pci = (struct virtio_pci_cfg_cap) {
+        .cap.cap_vndr = PCI_CAP_ID_VNDR,
+        .cap.cap_next = 0,
+        .cap.cap_len  = sizeof(info.virtio.pci),
+        .cap.cfg_type = VIRTIO_PCI_CAP_PCI_CFG,
+    };
+
+    rc = pci_device_register(&info);
+    if (rc < 0)
+        goto fail1;
+
+    rc = pci_bar_register(1,
+                          PCI_BASE_ADDRESS_SPACE_MEMORY |
+                          PCI_BASE_ADDRESS_MEM_PREFETCH,
+                          8,
+                          &device_memory_ops,
+                          vdev);
+    if (rc < 0)
+        goto fail2;
+
+    rc = demu_register_memory_space(vpci->cfg_base, 0x8000,
+                                    pci_config_mmio_callback, vpci);
+    if (rc < 0)
+        goto fail3;
+
+    return 0;
+
+fail3:
+    DBG("fail3\n");
+
+    pci_bar_deregister(1);
+
+fail2:
+    DBG("fail2\n");
+
+    pci_device_deregister();
+
+fail1:
+    DBG("fail1\n");
+
+    warnx("fail");
+    return rc;
+}
+
+int virtio_pci_exit(struct kvm *kvm, struct virtio_device *vdev)
+{
+    struct virtio_pci *vpci = vdev->virtio;
+
+    demu_deregister_memory_space(vpci->cfg_base);
+    pci_bar_deregister(1);
+    pci_device_deregister();
+    return 0;
+}
+
+int virtio_pci_reset(struct kvm *kvm, struct virtio_device *vdev)
+{
+    DBG("not implemented\n");
+    return -EFAULT;
+}
+
+int virtio_pci_init_vq(struct kvm *kvm, struct virtio_device *vdev, int vq)
+{
+    struct virtio_pci *vpci = vdev->virtio;
+    return vdev->ops->init_vq(kvm, vpci->dev, vq);
+}
+
+void virtio_pci_exit_vq(struct kvm *kvm, struct virtio_device *vdev, int vq)
+{
+    struct virtio_pci *vpci = vdev->virtio;
+
+    vpci->gsis[vq] = 0;
+    vpci->vq_vector[vq] = VIRTIO_MSI_NO_VECTOR;
+    virtio_exit_vq(kvm, vdev, vpci->dev, vq);
+}
+
+int virtio_pci_signal_vq(struct kvm *kvm, struct virtio_device *vdev, u32 vq)
+{
+    struct virtio_pci *vpci = vdev->virtio;
+
+    vpci->isr = VIRTIO_IRQ_HIGH;
+    kvm__irq_line(kvm, vpci->legacy_irq_line, VIRTIO_IRQ_HIGH);
+    return 0;
+}
+
+int virtio_pci_signal_config(struct kvm *kvm, struct virtio_device *vdev)
+{
+    DBG("not implemented\n");
+    return -EFAULT;
+}


### PR DESCRIPTION
A draft PR for initial virtio-pci transport backend support.
CLI inderface of virtio_disk not changed, as well as default behaviour. Only a bunch of code added, so that preliminary comments could be addressed. Patches to actually use this code and integrate it with Xen interface are yet to be presented. 